### PR TITLE
improved documentation for user.id/user_text

### DIFF
--- a/mw/xml_dump/iteration/contributor.py
+++ b/mw/xml_dump/iteration/contributor.py
@@ -20,11 +20,19 @@ class Contributor(serializable.Type):
         self.id = none_or(id, int)
         """
         User ID : int | `None` (if not specified in the XML)
+
+        User ID of a user if the contributor is signed into an account
+        in the while making the contribution and `None` when
+        contributors are not signed in.
         """
 
         self.user_text = none_or(user_text, str)
         """
         User name or IP address : str | `None` (if not specified in the XML)
+
+        If a user is logged in, this will reflect the users accout
+        name. If the user is not logged in, this will usually be
+        recorded as the IPv4 or IPv6 address in the XML.
         """
 
     @classmethod


### PR DESCRIPTION
As discussed on IRC. This should avoid the confusion I had about the fact that user_text is overloaded so that it is includes both a username if the name is defined and an IP address if it's not. Please edit away to make it more clear, etc. :) 
