### PR TITLE
Switch from multiprocessing to multiprocess since it can serialise more stuff

### DIFF
--- a/mw/xml_dump/map.py
+++ b/mw/xml_dump/map.py
@@ -1,5 +1,5 @@
 import logging
-from multiprocessing import Queue, Value, cpu_count
+from multiprocess import Queue, Value, cpu_count
 from queue import Empty
 
 from .functions import file

--- a/mw/xml_dump/processor.py
+++ b/mw/xml_dump/processor.py
@@ -1,7 +1,7 @@
 import logging
 import traceback
 from collections import namedtuple
-from multiprocessing import Process
+from multiprocess import Process
 from queue import Empty
 
 from .functions import open_file

--- a/mw/xml_dump/tests/test_processor.py
+++ b/mw/xml_dump/tests/test_processor.py
@@ -1,5 +1,5 @@
 import io
-from multiprocessing import Queue
+from multiprocess import Queue
 
 from nose.tools import eq_, raises
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         "requests>=2.4",
-        "pymysql>=0.6.2"],
+        "pymysql>=0.6.2",
+        "multiprocess>=0.70.5"],
     test_suite='nose.collector',
     classifiers=[
         "Programming Language :: Python",


### PR DESCRIPTION
Like you said in the other PR, this project is being deprecated, so I'm not sure how useful this is. However, I got a bit unstuck with limitations in pickle, particularly not being able to pickle exceptions, which I wanted to propagate to my main process, and found this useful. Perhaps it could help in the replacement library also?