### PR TITLE
7z to 7za for decompressing 7z files

### DIFF
--- a/mw/xml_dump/functions.py
+++ b/mw/xml_dump/functions.py
@@ -8,7 +8,7 @@ EXTENSIONS = {
     'xml': ["cat"],
     'gz': ["zcat"],
     'bz2': ["bzcat"],
-    '7z': ["7z", "e", "-so"],
+    '7z': ["7za", "e", "-so"],
     'lzma': ["lzcat"]
 }
 """


### PR DESCRIPTION
7za is better spread over Linux distribution than 7z (ex. when you do calculation on a distant server where you can't install linux packages ;) )